### PR TITLE
feat(#0002): adicionar endpoint GET /clientes/cpf/{cpf}

### DIFF
--- a/SistemaPedidos.API/Controllers/ClientesController.cs
+++ b/SistemaPedidos.API/Controllers/ClientesController.cs
@@ -46,6 +46,20 @@ public class ClientesController : ControllerBase
         return Ok(clientesDto);
     }
 
+    // GET: api/v1/clientes/cpf/{cpf}
+    [HttpGet("{cpf}")]
+    public async Task<ActionResult<ClienteReadDTO>> GetByCpf(string cpf)
+    {
+        var cliente = await _unitOfWork.Clientes.GetByCpfAsync(cpf);
+
+        if (cliente is null)
+            return NotFound();
+
+        var clienteDto = _mapper.Map<ClienteReadDTO>(cliente);
+
+        return Ok(clienteDto);
+    }
+
     // GET: api/v1/clientes/{id}
     [HttpGet("{id}")]
     public async Task<ActionResult<ClienteReadDTO>> GetById(Guid id)

--- a/SistemaPedidos.Domain/Repositories/IClienteRepository.cs
+++ b/SistemaPedidos.Domain/Repositories/IClienteRepository.cs
@@ -7,6 +7,7 @@ public interface IClienteRepository
     Task AddAsync(Cliente cliente);
     Task<IEnumerable<Cliente>> GetAllAsync();
     Task<Cliente?> GetByIdAsync(Guid id);
+    Task<Cliente?> GetByCpfAsync(string cpf);
     void Update(Cliente cliente);
     void Delete(Cliente cliente);
 }

--- a/SistemaPedidos.Infrastructure/Repositories/ClienteRepository.cs
+++ b/SistemaPedidos.Infrastructure/Repositories/ClienteRepository.cs
@@ -34,6 +34,13 @@ public class ClienteRepository : IClienteRepository
             .FirstOrDefaultAsync(c => c.Id == id);
     }
 
+    public async Task<Cliente?> GetByCpfAsync(string cpf)
+    {
+        return await _context.Clientes
+            .AsNoTracking()
+            .FirstOrDefaultAsync(c => c.CPF == cpf);
+    }
+
     public void Update(Cliente cliente)
     {
         _context.Clientes.Update(cliente);


### PR DESCRIPTION
1. **Arquivos atualizados**

- ClientesController.cs: adicionado GET api/v1/clientes/cpf/{cpf} (GetByCpf), retorna 200 ou 404.

- ClienteRepository.cs: implementado GetByCpfAsync com AsNoTracking().

- IClienteRepository.cs: adicionada assinatura GetByCpfAsync.

2.  **O que foi implementado**
Novo endpoint GET api/v1/clientes/cpf/{cpf} para recuperar cliente por CPF.